### PR TITLE
Fixed problem with running vim.exe in a windows shell.

### DIFF
--- a/config/keybindings.vim
+++ b/config/keybindings.vim
@@ -5,7 +5,7 @@
 """"""""""""""""""""""""""""""""""""""""
 
 " fix arrow keys in console mode
-if !has('gui_running')
+if !(has('gui_running') || has('win32'))
     set term=ansi
 endif
 


### PR DESCRIPTION
I was having a problem launching vim.exe from inside a windows shell because config/keybindings.vim was setting term="ansi" if it didn't detect a GUI. I included a check for win32 and now vim.exe and gvim.exe both work correctly in windows.
